### PR TITLE
Fixes for QEMU run scripts

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-qemu-system-riscv64 -machine virt -cpu rv64,x-h=true -nographic -serial mon:stdio -m size=4095M -kernel images/sel4-riscv-vmm-image-riscv-spike
+qemu-system-riscv64 -bios none -machine virt -cpu rv64,x-h=true -nographic -serial mon:stdio -m size=4095M -kernel images/sel4-riscv-vmm-image-riscv-spike
 

--- a/run_smp.sh
+++ b/run_smp.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-qemu-system-riscv64 -bios none -machine virt -cpu rv64,h=true -smp 4 -nographic -serial mon:stdio -m size=4095M -kernel images/sel4-riscv-vmm-image-riscv-spike
+qemu-system-riscv64 -bios none -machine virt -cpu rv64,x-h=true -smp 4 -nographic -serial mon:stdio -m size=4095M -kernel images/sel4-riscv-vmm-image-riscv-spike
 

--- a/run_smp.sh
+++ b/run_smp.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-qemu-system-riscv64 -machine virt -cpu rv64,h=true -smp 4 -nographic -serial mon:stdio -m size=4095M -kernel images/sel4-riscv-vmm-image-riscv-spike
+qemu-system-riscv64 -bios none -machine virt -cpu rv64,h=true -smp 4 -nographic -serial mon:stdio -m size=4095M -kernel images/sel4-riscv-vmm-image-riscv-spike
 


### PR DESCRIPTION
These changes fix the scripts such that they can be used with the version of QEMU that is part of the seL4 Docker container (v5.2). They also work with QEMU v6.0.

QEMU 5.1 changed the default behavior from `-bios none` to `-bios default` which means these commands no longer work on current versions of QEMU, the default behavior will load QEMU's default OpenSBI firmware, instead of the firmware produced by the project's build system. So, we must explicitly specify that the image passed in has the firmware with `-bios none`.

The other change fixes the hypervisor extension option for `run_smp.sh`, making it match the current `run.sh`.